### PR TITLE
fix: bump spring-ldap-core to 2.4.4 for CVE-2024-38829

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-web:2.7.5'
-    api 'org.springframework.ldap:spring-ldap-core:2.4.1'
+    api 'org.springframework.ldap:spring-ldap-core:2.4.4'
     api 'org.springframework.security.oauth:spring-security-oauth2:2.5.2.RELEASE'
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'org.yaml:snakeyaml:1.33'


### PR DESCRIPTION
## Summary
- Bumps `spring-ldap-core` from 2.4.1 to 2.4.4 to address [CVE-2024-38829](https://nvd.nist.gov/vuln/detail/CVE-2024-38829) (sensitive data exposure via case-sensitive comparisons in Spring LDAP).
- 2.4.4 is the latest release on the 2.x line and contains the backport of the fix. The 3.x line is not viable here because it requires Java 17, and this module targets Java 11.
- `spring-ldap-core` is declared as `api`, so the upgrade also removes the transitive CVE for downstream consumers.