### PR TITLE
fix: throw EntityFoundException on duplicate NAM OAuth client

### DIFF
--- a/src/main/java/no/fint/portal/exceptions/EntityFoundException.java
+++ b/src/main/java/no/fint/portal/exceptions/EntityFoundException.java
@@ -4,4 +4,8 @@ public class EntityFoundException extends RuntimeException {
     public EntityFoundException(String message) {
         super(message);
     }
+
+    public EntityFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/no/fint/portal/oauth/NamOAuthClientService.java
+++ b/src/main/java/no/fint/portal/oauth/NamOAuthClientService.java
@@ -3,6 +3,7 @@ package no.fint.portal.oauth;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import no.fint.portal.exceptions.EntityFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -10,11 +11,11 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.OAuth2RestTemplate;
 import org.springframework.security.oauth2.client.token.grant.password.ResourceOwnerPasswordResourceDetails;
+import org.springframework.security.oauth2.common.exceptions.OAuth2Exception;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import javax.annotation.PostConstruct;
-import java.io.IOException;
 import java.util.Collections;
 
 @Service
@@ -72,10 +73,26 @@ public class NamOAuthClientService {
             OAuthClient client = mapper.readValue(response, OAuthClient.class);
             log.info("Client ID {} created.", client.getClientId());
             return client;
+        } catch (OAuth2Exception e) {
+            if (isAlreadyExists(e)) {
+                log.warn("OAuth client {} already exists in NAM", name);
+                throw new EntityFoundException(String.format("OAuth client already exists in NAM: %s", name), e);
+            }
+            log.error("Unable to create client {}", name, e);
+            throw new RuntimeException(e);
         } catch (Exception e) {
             log.error("Unable to create client {}", name, e);
             throw new RuntimeException(e);
         }
+    }
+
+    // NAM has no structured "already exists" signal — it returns the generic OAuth2 "invalid_client"
+    // code for several distinct conditions (bad creds, missing client, duplicate, ...). The only way
+    // to single out a duplicate is the human-readable description. Revisit if NAM exposes a cleaner signal.
+    private static boolean isAlreadyExists(OAuth2Exception e) {
+        return "invalid_client".equals(e.getOAuth2ErrorCode())
+                && e.getMessage() != null
+                && e.getMessage().toLowerCase().contains("already exists");
     }
 
     public void removeOAuthClient(String clientId) {

--- a/src/test/groovy/no/fint/portal/oauth/NamOAuthClientServiceSpec.groovy
+++ b/src/test/groovy/no/fint/portal/oauth/NamOAuthClientServiceSpec.groovy
@@ -1,8 +1,10 @@
 package no.fint.portal.oauth
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import no.fint.portal.exceptions.EntityFoundException
 import org.springframework.http.HttpEntity
 import org.springframework.security.oauth2.client.OAuth2RestTemplate
+import org.springframework.security.oauth2.common.exceptions.InvalidClientException
 import spock.lang.Specification
 
 class NamOAuthClientServiceSpec extends Specification {
@@ -27,5 +29,33 @@ class NamOAuthClientServiceSpec extends Specification {
         client != null
         !client.getClientId().isEmpty()
         !client.getClientSecret().isEmpty()
+    }
+
+    def "Add OAuth Client throws EntityFoundException when NAM reports invalid_client/already exists"() {
+        given:
+        def cause = new InvalidClientException("The client already exists. Please contact administrator")
+
+        when:
+        namOAuthClientService.addOAuthClient("c_duplicate")
+
+        then:
+        1 * restTemplate.postForObject(_ as String, _ as HttpEntity, _ as Class, _) >> { throw cause }
+        def thrown = thrown(EntityFoundException)
+        thrown.message == "OAuth client already exists in NAM: c_duplicate"
+        thrown.cause.is(cause)
+    }
+
+    def "Add OAuth Client wraps unrelated OAuth2Exception in RuntimeException"() {
+        given:
+        def cause = new InvalidClientException("Bad credentials")
+
+        when:
+        namOAuthClientService.addOAuthClient("c_other")
+
+        then:
+        1 * restTemplate.postForObject(_ as String, _ as HttpEntity, _ as Class, _) >> { throw cause }
+        def thrown = thrown(RuntimeException)
+        !(thrown instanceof EntityFoundException)
+        thrown.cause.is(cause)
     }
 }


### PR DESCRIPTION
## Summary

`NamOAuthClientService.addOAuthClient` previously caught everything and re-threw as a bare `RuntimeException`, including NAM's "client already exists" response. Consumers (e.g. `fint-kunde-portal-backend`) couldn't tell a duplicate apart from a generic failure, so duplicates surfaced as HTTP 500 instead of 409.

This matters when LDAP and NAM go out of sync: the LDAP entry is missing (so the existing duplicate check in `ClientService.addClient` passes) but the OAuth client is still registered in NAM. The downstream POST then leaks a 500.

## Changes

- `NamOAuthClientService.addOAuthClient` now catches `OAuth2Exception`, inspects the OAuth2 error code and description, and throws `EntityFoundException("OAuth client already exists in NAM: <name>", cause)` for the duplicate case. Anything else is wrapped in `RuntimeException` exactly as before. This mirrors the existing LDAP-duplicate translation in `ClientService.addClient` (PR #41), so the library is now consistent across both backing systems.
- `EntityFoundException` gets a `(message, cause)` constructor so the underlying `OAuth2Exception` is preserved for debugging.
- New unit tests on `NamOAuthClientServiceSpec`:
  - `invalid_client` + "already exists" → `EntityFoundException` (asserts message and cause).
  - Unrelated `invalid_client` (e.g. bad credentials) → still wraps to plain `RuntimeException`, not `EntityFoundException` — guards against over-classifying.

## Notes / caveats

NAM has no structured "already exists" signal — it returns the generic OAuth2 `invalid_client` code for several distinct conditions (bad creds, missing client, duplicate, …). The duplicate is identified by `invalid_client` + the "already exists" substring in the description. The helper has a comment flagging this as a workaround to revisit if NAM ever exposes a cleaner signal.

This is a behavior change but not a breaking API change: `EntityFoundException extends RuntimeException`, so callers still catching `RuntimeException` continue to work.